### PR TITLE
Fix potential memory leak in win32/console.c

### DIFF
--- a/contrib/win32/win32compat/console.c
+++ b/contrib/win32/win32compat/console.c
@@ -1608,7 +1608,13 @@ SCREEN_HANDLE ConSaveScreenHandle( SCREEN_HANDLE hScreen )
     }
 
 	if ( !pScreenRec->pScreenBuf )
+	{
+		// if we allocated a screen within this scope, free it before returning
+		if ( pScreenRec != (PSCREEN_RECORD)hScreen ) {
+			free(pScreenRec);
+		}
 		return NULL;
+	}
 
 	result =  ReadConsoleOutput( hConsole,				// handle of a console screen buffer 
 							 (PCHAR_INFO)(pScreenRec->pScreenBuf),	// address of buffer that receives data 


### PR DESCRIPTION
CAUTION: untested as my openssl installation has gone insane.

If the incoming "hScreen" parameter is NULL, a new PSCREEN_RECORD is
allocated to use in its place.
However, if the allocation of the "pScreenBuf" member variable fails,
the function returns, potentially leaking the newly allocated
PSCREEN_RECORD.

This fix first checks to see if the functions owns the "pScreenRec", and
if so, frees it before returning.