### PR TITLE
allow SSHd to work under single non-administrative account

### DIFF
--- a/contrib/win32/win32compat/pwd.c
+++ b/contrib/win32/win32compat/pwd.c
@@ -152,14 +152,23 @@ char *GetHomeDirFromToken(char *userName, HANDLE token)
   profileInfo.hProfile = NULL;
   profileInfo.dwSize = sizeof(profileInfo);
 
-
-  
   if (LoadUserProfile(token, &profileInfo) == FALSE)
   {
-    debug("<- GetHomeDirFromToken()...");
-    debug("LoadUserProfile failure: %d", GetLastError());
-    
-    return NULL;
+    DWORD errorCode = GetLastError();
+    char currentUser[UNLEN + 1];
+    DWORD usernamelen = UNLEN + 1;
+    if (GetUserName(currentUser, &usernamelen) && strcmp(userName, currentUser) == 0)
+    {
+      debug("WARNING. Could not load user profile (%u).", errorCode);
+    }
+    else
+    {
+      debug("<- GetHomeDirFromToken()...");
+
+      debug("LoadUserProfile failure: %d", errorCode);
+
+      return NULL;
+    }
   }
 
   /*


### PR DESCRIPTION
Problem: launching sshd under non-administrative account and then connecting with the same account would not work, because SSHd fails to load user profile (which in this case is unnecessary).

Fix: check, if connecting user is the same one, who runs current SSHd. If that is the case, make a failure to LoadUserProfile be reported as a warning, and continue login process.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/win32-openssh/163)

<!-- Reviewable:end -->
