### PR TITLE
Allow powershell script to be ran from any location and update to pow…

### DIFF
--- a/contrib/win32/openssh/install-sshlsa.ps1
+++ b/contrib/win32/openssh/install-sshlsa.ps1
@@ -1,4 +1,4 @@
-﻿copy .\ssh-lsa.dll $env:windir\system32
+Copy-Item -Path $PSScriptRoot\ssh-lsa.dll -Destination "$env:windir\system32"
 $subkey = 'SYSTEM\CurrentControlSet\Control\Lsa'
 $value  = 'Authentication Packages'
 $reg = [Microsoft.Win32.RegistryKey]::OpenBaseKey('LocalMachine', 0)


### PR DESCRIPTION
…ershell copy method

Adding in $PSScriptRoot allows this powershell script to be ran from anywhere. Before if you were not in the openssh directory in powershell it wouldn't be able to find ssh-lsa.dll Also switched the copy method to the powershell method of copying files.
