### PR TITLE
sAuthorized(Principals/Keys)Command update command path format to acc…

### DIFF
--- a/servconf.c
+++ b/servconf.c
@@ -1736,7 +1736,7 @@ process_server_config_line(ServerOptions *options, char *line,
 			    linenum);
 		len = strspn(cp, WHITESPACE);
 		if (*activep && options->authorized_keys_command == NULL) {
-			if (cp[len] != '/' && strcasecmp(cp + len, "none") != 0)
+			if (cp[len] != '/' && strcasecmp(cp + len, "none") != 0 && !(isalpha(cp[len]) && cp[len + 1] == ':' && cp[len+2] == '\\'))
 				fatal("%.200s line %d: AuthorizedKeysCommand "
 				    "must be an absolute path",
 				    filename, linenum);
@@ -1762,7 +1762,7 @@ process_server_config_line(ServerOptions *options, char *line,
 		len = strspn(cp, WHITESPACE);
 		if (*activep &&
 		    options->authorized_principals_command == NULL) {
-			if (cp[len] != '/' && strcasecmp(cp + len, "none") != 0)
+			if (cp[len] != '/' && strcasecmp(cp + len, "none") != 0 && !(isalpha(cp[len]) && cp[len + 1] == ':' && cp[len+2] == '\\'))
 				fatal("%.200s line %d: "
 				    "AuthorizedPrincipalsCommand must be "
 				    "an absolute path", filename, linenum);


### PR DESCRIPTION
…ept windows path format

Currently AuthorizedPrincipalsCommand expects the command path to start with `/` which is not the case for windows as the path starts with C:/Programdata/<blah>.
similarly for AuthorizedKeysCommand.