### PR TITLE
Corrected false info which only pertained to Linux

### DIFF
--- a/README
+++ b/README
@@ -1,15 +1,18 @@
-See https://www.openssh.com/releasenotes.html#7.5p1 for the release notes.
+This is a fork of openssh/openssh-portable, and a port of 
+OpenBSD's excellent OpenSSH[0] to Windows.
 
-Please read https://www.openssh.com/report.html for bug reporting
-instructions and note that we do not use Github for bug reporting or
+Note that OpenSSH for Windows uses Github for bug reporting and 
 patch/pull-request management.
+
+Instructions to report bus for openssh/openssh-portable are here: 
+https://www.openssh.com/report.html
+
+See https://www.openssh.com/releasenotes.html#7.5p1 for the release 
+notes for openssh/openssh-portable.
 
 - A Japanese translation of this document and of the release notes is
 - available at http://www.unixuser.org/~haruyama/security/openssh/index.html
 - Thanks to HARUYAMA Seigo <haruyama@unixuser.org>
-
-This is the port of OpenBSD's excellent OpenSSH[0] to Linux and other
-Unices.
 
 OpenSSH is based on the last free version of Tatu Ylonen's sample
 implementation with all patent-encumbered algorithms removed (to
@@ -18,13 +21,7 @@ reintroduced and many other clean-ups.  OpenSSH has been created by
 Aaron Campbell, Bob Beck, Markus Friedl, Niels Provos, Theo de Raadt,
 and Dug Song. It has a homepage at https://www.openssh.com/
 
-This port consists of the re-introduction of autoconf support, PAM
-support, EGD[1]/PRNGD[2] support and replacements for OpenBSD library
-functions that are (regrettably) absent from other unices. This port
-has been best tested on AIX, Cygwin, HP-UX, Linux, MacOS/X,
-NetBSD, OpenBSD, OpenServer, Solaris, Unicos, and UnixWare.
-
-This version actively tracks changes in the OpenBSD CVS repository.
+This contains autoconf support, PAM support, and EGD[1]/PRNGD[2] support. 
 
 The PAM support is now more functional than the popular packages of
 commercial ssh-1.2.x. It checks "account" and "session" modules for
@@ -32,24 +29,24 @@ all logins, not just when using password authentication.
 
 OpenSSH depends on Zlib[3], OpenSSL[4] and optionally PAM[5].
 
-There is now several mailing lists for this port of OpenSSH. Please
+There is now several mailing lists for openssh/openssh-portable. Please
 refer to https://www.openssh.com/list.html for details on how to join.
 
-Please send bug reports and patches to the mailing list
-openssh-unix-dev@mindrot.org. The list is open to posting by unsubscribed
-users.  Code contribution are welcomed, but please follow the OpenBSD
+Please use github to submit bug reports and pull requests.  
+Code contribution are welcomed, but please follow the OpenBSD
 style guidelines[6].
 
-Please refer to the INSTALL document for information on how to install
-OpenSSH on your system.
+Please refer to the "Releases" tab to install OpenSSH on your 
+Windows system.
 
 Damien Miller <djm@mindrot.org>
 
 Miscellania -
 
-This version of OpenSSH is based upon code retrieved from the OpenBSD
-CVS repository which in turn was based on the last free sample
-implementation released by Tatu Ylonen.
+This version of OpenSSH is based upon openssh/openssh-portable, which in 
+turn is based on code retrieved from the OpenBSD CVS repository, which 
+in turn was based on the last free sample implementation released by 
+Tatu Ylonen.
 
 References -
 


### PR DESCRIPTION
Also removed instructions to read the "INSTALL" document for info on how to install, since "INSTALL" contains no correct info.