### PR TITLE
Fixed Mode String For Symbolic Links

### DIFF
--- a/contrib/win32/win32compat/misc.c
+++ b/contrib/win32/win32compat/misc.c
@@ -489,6 +489,10 @@ strmode(mode_t mode, char *p)
 	case _S_IFIFO:			/* fifo */
 		*p++ = 'p';
 		break;
+	case _S_IFLNK | S_IFDIR:	/* link */
+	case _S_IFLNK:			
+		*p++ = 'l';
+		break;			
 	default:			/* unknown */
 		*p++ = '?';
 		break;


### PR DESCRIPTION
- Addressed issue where links to files and directories were being sent back as '?' which confused SFTP clients.