### PR TITLE
updating readme with link to the WIKI + adding in documentation to get public key authentication to work

### DIFF
--- a/README
+++ b/README
@@ -1,6 +1,7 @@
 As of Nov 1st 2016, active development on "Windows for OpenSSH" is being done in https://github.com/PowerShell/openssh-portable. 
 
-This repo (https://github.com/PowerShell/Win32-OpenSSH) is being maintained to keep track of releases and issues.
+This repo (https://github.com/PowerShell/Win32-OpenSSH) is being maintained to keep track of releases and issues. The 
+[Documentation](https://github.com/PowerShell/Win32-OpenSSH/wiki) for the project is also maintained here in the wiki. 
 
 Release History:
 7/26/2018 -- Release 7.7.2.0 with source https://github.com/PowerShell/openssh-portable/releases/tag/v7.7.2.0


### PR DESCRIPTION
Good Evening,

This PR itself has a very minor update to the readme with a link indicating that the Wiki is still in use for documentation. However, I also followed [the suggested procedure here](https://gist.github.com/larrybotha/10650410) for contributing to the wiki and made some updates to the certificate authentication page which doesn't  currently include any instructions for how to make it work for administrators. I'm not actually sure if the instructions there even work for regular users.

You can view the documentation updates on my fork here -> https://github.com/BillDinger/Win32-OpenSSH/wiki/Certificate-Authentication under the section `Setup SSHD Server for Administrator certificate based authentication` I have verified them on server 2019 & 2016 from mac & windows clients.