### PR TITLE
Add reproducible ARM64 client artifact

### DIFF
--- a/.github/workflows/arm64-client.yml
+++ b/.github/workflows/arm64-client.yml
@@ -35,19 +35,19 @@ jobs:
 
     steps:
       - name: Check out release automation
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           path: release-repo
 
       - name: Check out exact OpenSSH source
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           repository: PowerShell/openssh-portable
           ref: ${{ env.OPENSSH_SOURCE_REVISION }}
           path: openssh-portable
 
       - name: Check out dependency registry
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           repository: microsoft/vcpkg
           ref: ${{ env.VCPKG_BASELINE }}
@@ -132,7 +132,7 @@ jobs:
             -PackageDirectory "$env:GITHUB_WORKSPACE\OpenSSH-ARM64-Client"
 
       - name: Upload traceable client artifact
-        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: OpenSSH-ARM64-Client-v10.0.0.0
           path: OpenSSH-ARM64-Client
@@ -142,7 +142,7 @@ jobs:
 
       - name: Upload build logs on failure
         if: failure()
-        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: OpenSSH-ARM64-build-logs
           path: |

--- a/.github/workflows/arm64-client.yml
+++ b/.github/workflows/arm64-client.yml
@@ -1,0 +1,153 @@
+name: ARM64 client artifact
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - .github/workflows/arm64-client.yml
+      - eng/openssh-portable-v10.0.0.0-vcpkg.patch
+      - scripts/New-OpenSSHClientPackage.ps1
+      - tests/Invoke-OpenSSHClientSmoke.ps1
+      - tests/Invoke-OpenSSHUnitTests.ps1
+      - tests/Test-OpenSSHClientPackage.ps1
+  push:
+    paths:
+      - .github/workflows/arm64-client.yml
+      - eng/openssh-portable-v10.0.0.0-vcpkg.patch
+      - scripts/New-OpenSSHClientPackage.ps1
+      - tests/Invoke-OpenSSHClientSmoke.ps1
+      - tests/Invoke-OpenSSHUnitTests.ps1
+      - tests/Test-OpenSSHClientPackage.ps1
+
+permissions:
+  contents: read
+
+env:
+  OPENSSH_SOURCE_REVISION: b8c08ef9da9450a94a9c5ef717d96a7bd83f3332
+  OPENSSH_SOURCE_REF: v10.0.0.0
+  VCPKG_BASELINE: 16fa044f80dd984c24deff5b7d0457e64c85a1e0
+
+jobs:
+  build-test-package:
+    name: Build, test, and package native ARM64 client
+    runs-on: windows-11-arm
+    timeout-minutes: 120
+
+    steps:
+      - name: Check out release automation
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        with:
+          path: release-repo
+
+      - name: Check out exact OpenSSH source
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        with:
+          repository: PowerShell/openssh-portable
+          ref: ${{ env.OPENSSH_SOURCE_REVISION }}
+          path: openssh-portable
+
+      - name: Check out dependency registry
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        with:
+          repository: microsoft/vcpkg
+          ref: ${{ env.VCPKG_BASELINE }}
+          path: vcpkg
+
+      - name: Verify ARM64 build prerequisites
+        shell: pwsh
+        run: |
+          $vswhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
+          $visualStudio = & $vswhere -products * -requires Microsoft.VisualStudio.Component.VC.Tools.ARM64 -property installationPath
+          if (-not $visualStudio) {
+            throw 'Visual Studio ARM64 C++ tools are not installed on the runner.'
+          }
+          $spectre = & $vswhere -products * -requires Microsoft.VisualStudio.Component.VC.Runtimes.ARM64.Spectre -property installationPath
+          if (-not $spectre) {
+            throw 'The v143 ARM64 Spectre libraries required by arm64-custom.cmake are not installed on the runner.'
+          }
+          Write-Host "Using Visual Studio at $visualStudio"
+
+      - name: Apply reproducible dependency lock
+        shell: pwsh
+        run: |
+          git -C openssh-portable apply "$env:GITHUB_WORKSPACE\release-repo\eng\openssh-portable-v10.0.0.0-vcpkg.patch"
+          if ($LASTEXITCODE -ne 0) {
+            throw 'The dependency servicing patch no longer applies to the pinned OpenSSH source.'
+          }
+
+      - name: Bootstrap vcpkg
+        shell: pwsh
+        run: |
+          & "$env:GITHUB_WORKSPACE\vcpkg\bootstrap-vcpkg.bat" -disableMetrics
+          if ($LASTEXITCODE -ne 0) {
+            throw "vcpkg bootstrap failed with exit code $LASTEXITCODE."
+          }
+          & "$env:GITHUB_WORKSPACE\vcpkg\vcpkg.exe" integrate install
+          if ($LASTEXITCODE -ne 0) {
+            throw "vcpkg MSBuild integration failed with exit code $LASTEXITCODE."
+          }
+
+      - name: Build OpenSSH from source
+        shell: powershell
+        run: |
+          & "$env:GITHUB_WORKSPACE\openssh-portable\contrib\win32\openssh\OpenSSH-build.ps1" `
+            -repolocation "$env:GITHUB_WORKSPACE\openssh-portable" `
+            -destination "$env:GITHUB_WORKSPACE\source-packages" `
+            -NativeHostArch arm64 `
+            -Configuration Release `
+            -Verbose
+          if ($LASTEXITCODE -ne 0) {
+            throw "OpenSSH ARM64 build failed with exit code $LASTEXITCODE."
+          }
+
+      - name: Run upstream unit tests
+        shell: powershell
+        run: |
+          & "$env:GITHUB_WORKSPACE\release-repo\tests\Invoke-OpenSSHUnitTests.ps1" `
+            -BuildDirectory "$env:GITHUB_WORKSPACE\openssh-portable\bin\arm64\Release"
+
+      - name: Exercise native client behavior
+        shell: powershell
+        run: |
+          & "$env:GITHUB_WORKSPACE\release-repo\tests\Invoke-OpenSSHClientSmoke.ps1" `
+            -BuildDirectory "$env:GITHUB_WORKSPACE\openssh-portable\bin\arm64\Release"
+
+      - name: Create Git for Windows client payload
+        shell: powershell
+        run: |
+          & "$env:GITHUB_WORKSPACE\release-repo\scripts\New-OpenSSHClientPackage.ps1" `
+            -BuildDirectory "$env:GITHUB_WORKSPACE\openssh-portable\bin\arm64\Release" `
+            -DestinationDirectory "$env:GITHUB_WORKSPACE\OpenSSH-ARM64-Client" `
+            -SourceRevision "$env:OPENSSH_SOURCE_REVISION" `
+            -SourceRef "$env:OPENSSH_SOURCE_REF" `
+            -VcpkgBaseline "$env:VCPKG_BASELINE" `
+            -BuildRepository "$env:GITHUB_REPOSITORY" `
+            -BuildRevision "$env:GITHUB_SHA" `
+            -BuildRun "$env:GITHUB_SERVER_URL/$env:GITHUB_REPOSITORY/actions/runs/$env:GITHUB_RUN_ID"
+
+      - name: Verify client-only artifact
+        shell: powershell
+        run: |
+          & "$env:GITHUB_WORKSPACE\release-repo\tests\Test-OpenSSHClientPackage.ps1" `
+            -PackageDirectory "$env:GITHUB_WORKSPACE\OpenSSH-ARM64-Client"
+
+      - name: Upload traceable client artifact
+        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08
+        with:
+          name: OpenSSH-ARM64-Client-v10.0.0.0
+          path: OpenSSH-ARM64-Client
+          if-no-files-found: error
+          compression-level: 9
+          retention-days: 30
+
+      - name: Upload build logs on failure
+        if: failure()
+        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08
+        with:
+          name: OpenSSH-ARM64-build-logs
+          path: |
+            openssh-portable/contrib/win32/openssh/OpenSSHReleasearm64.log
+            openssh-portable/contrib/win32/openssh/vcpkg_installed/arm64-custom/vcpkg/issue_body.md
+            smoke-logs/sshd.log
+          if-no-files-found: ignore
+          retention-days: 7

--- a/README.md
+++ b/README.md
@@ -4,6 +4,20 @@ This repo (https://github.com/PowerShell/Win32-OpenSSH) is being maintained to k
 and because it contains the [wiki](https://github.com/PowerShell/Win32-OpenSSH/wiki)
 which has instructions for [building](https://github.com/PowerShell/Win32-OpenSSH/wiki/Building-OpenSSH-for-Windows-(using-LibreSSL-crypto)).
 
+### ARM64 client artifact
+
+The `ARM64 client artifact` workflow rebuilds the `v10.0.0.0` source tag on a native
+Windows ARM64 runner, runs the upstream unit tests and client integration smoke
+tests, verifies every packaged PE has machine type `0xAA64`, and publishes a
+client-only payload laid out for Git for Windows.
+
+The artifact manifest records the exact OpenSSH source commit, vcpkg baseline,
+workflow commit, per-file SHA-256 hashes, and the disposition of all 11 existing
+Git for Windows OpenSSH paths. Ten paths receive native replacements.
+`usr/lib/ssh/ssh-keysign.exe` is removed because Win32 OpenSSH does not build it
+and does not support host-based authentication. Server daemons, service scripts,
+server configuration, and shell-host files are excluded from the artifact.
+
 ### Release History
 
 | Date | Version | Release with source |

--- a/eng/openssh-portable-v10.0.0.0-vcpkg.patch
+++ b/eng/openssh-portable-v10.0.0.0-vcpkg.patch
@@ -1,0 +1,11 @@
+diff --git a/contrib/win32/openssh/vcpkg.json b/contrib/win32/openssh/vcpkg.json
+index 825f19c08..9808b7e93 100644
+--- a/contrib/win32/openssh/vcpkg.json
++++ b/contrib/win32/openssh/vcpkg.json
+@@ -23,5 +23,5 @@
+       "version": "0.13.0"
+     }
+   ],
+-  "builtin-baseline": "a345bbdc68cdfda65603e24413b21afb28f110fb"
++  "builtin-baseline": "16fa044f80dd984c24deff5b7d0457e64c85a1e0"
+ }

--- a/scripts/New-OpenSSHClientPackage.ps1
+++ b/scripts/New-OpenSSHClientPackage.ps1
@@ -1,0 +1,185 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)]
+    [ValidateScript({ Test-Path $_ -PathType Container })]
+    [string] $BuildDirectory,
+
+    [Parameter(Mandatory)]
+    [string] $DestinationDirectory,
+
+    [Parameter(Mandatory)]
+    [ValidatePattern('^[0-9a-fA-F]{40}$')]
+    [string] $SourceRevision,
+
+    [string] $SourceRepository = 'PowerShell/openssh-portable',
+    [string] $SourceRef = '',
+
+    [ValidatePattern('^[0-9a-fA-F]{40}$')]
+    [string] $VcpkgBaseline = '16fa044f80dd984c24deff5b7d0457e64c85a1e0',
+
+    [string] $BuildRepository = '',
+    [string] $BuildRevision = '',
+    [string] $BuildRun = ''
+)
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version 2.0
+
+$arm64Machine = 0xAA64
+$clientFiles = @(
+    [pscustomobject]@{ Source = 'scp.exe'; Destination = 'usr/bin/scp.exe' }
+    [pscustomobject]@{ Source = 'sftp.exe'; Destination = 'usr/bin/sftp.exe' }
+    [pscustomobject]@{ Source = 'ssh-add.exe'; Destination = 'usr/bin/ssh-add.exe' }
+    [pscustomobject]@{ Source = 'ssh-agent.exe'; Destination = 'usr/bin/ssh-agent.exe' }
+    [pscustomobject]@{ Source = 'ssh-keygen.exe'; Destination = 'usr/bin/ssh-keygen.exe' }
+    [pscustomobject]@{ Source = 'ssh-keyscan.exe'; Destination = 'usr/bin/ssh-keyscan.exe' }
+    [pscustomobject]@{ Source = 'ssh.exe'; Destination = 'usr/bin/ssh.exe' }
+    [pscustomobject]@{ Source = 'sftp-server.exe'; Destination = 'usr/lib/ssh/sftp-server.exe' }
+    [pscustomobject]@{ Source = 'ssh-pkcs11-helper.exe'; Destination = 'usr/lib/ssh/ssh-pkcs11-helper.exe' }
+    [pscustomobject]@{ Source = 'ssh-sk-helper.exe'; Destination = 'usr/lib/ssh/ssh-sk-helper.exe' }
+)
+$runtimeFiles = @(
+    # The Windows port resolves these helpers beside ssh.exe, while Git for
+    # Windows also owns canonical copies under usr/lib/ssh.
+    [pscustomobject]@{ Source = 'ssh-pkcs11-helper.exe'; Destination = 'usr/bin/ssh-pkcs11-helper.exe' }
+    [pscustomobject]@{ Source = 'ssh-sk-helper.exe'; Destination = 'usr/bin/ssh-sk-helper.exe' }
+    [pscustomobject]@{ Source = 'libcrypto.dll'; Destination = 'usr/bin/libcrypto.dll' }
+    [pscustomobject]@{ Source = 'libcrypto.dll'; Destination = 'usr/lib/ssh/libcrypto.dll' }
+)
+$metadataFiles = @('LICENSE.txt', 'NOTICE.txt')
+$serverOnlyNames = @(
+    'sshd.exe',
+    'sshd-auth.exe',
+    'sshd-session.exe',
+    'ssh-shellhost.exe',
+    'install-sshd.ps1',
+    'uninstall-sshd.ps1',
+    'sshd_config_default',
+    'openssh-events.man',
+    'moduli'
+)
+
+function Get-PEMachine {
+    param(
+        [Parameter(Mandatory)]
+        [string] $Path
+    )
+
+    $stream = [System.IO.File]::OpenRead($Path)
+    try {
+        $reader = New-Object System.IO.BinaryReader($stream)
+        if ($reader.ReadUInt16() -ne 0x5A4D) {
+            throw "'$Path' does not have an MZ header."
+        }
+
+        $stream.Position = 0x3c
+        $peOffset = $reader.ReadInt32()
+        if ($peOffset -lt 0 -or $peOffset -gt ($stream.Length - 6)) {
+            throw "'$Path' has an invalid PE header offset."
+        }
+
+        $stream.Position = $peOffset
+        if ($reader.ReadUInt32() -ne 0x00004550) {
+            throw "'$Path' does not have a PE signature."
+        }
+
+        return $reader.ReadUInt16()
+    }
+    finally {
+        $stream.Dispose()
+    }
+}
+
+function Copy-PayloadFile {
+    param(
+        [Parameter(Mandatory)]
+        [pscustomobject] $Mapping
+    )
+
+    $sourcePath = Join-Path $BuildDirectory $Mapping.Source
+    if (-not (Test-Path $sourcePath -PathType Leaf)) {
+        throw "Required client payload '$($Mapping.Source)' is missing from '$BuildDirectory'."
+    }
+
+    $machine = Get-PEMachine -Path $sourcePath
+    if ($machine -ne $arm64Machine) {
+        throw "'$sourcePath' has PE machine 0x$($machine.ToString('X4')); expected ARM64 0xAA64."
+    }
+
+    $relativePath = $Mapping.Destination.Replace('/', [System.IO.Path]::DirectorySeparatorChar)
+    $destinationPath = Join-Path $DestinationDirectory $relativePath
+    $null = New-Item -ItemType Directory -Path (Split-Path $destinationPath -Parent) -Force
+    Copy-Item -Path $sourcePath -Destination $destinationPath -Force
+
+    $item = Get-Item $destinationPath
+    return [ordered]@{
+        path = $Mapping.Destination
+        source = $Mapping.Source
+        size = $item.Length
+        sha256 = (Get-FileHash -Path $destinationPath -Algorithm SHA256).Hash.ToLowerInvariant()
+        machine = '0xAA64'
+    }
+}
+
+if (Test-Path $DestinationDirectory) {
+    Remove-Item -Path $DestinationDirectory -Recurse -Force
+}
+$null = New-Item -ItemType Directory -Path $DestinationDirectory -Force
+
+$manifestFiles = @()
+foreach ($mapping in ($clientFiles + $runtimeFiles)) {
+    $manifestFiles += Copy-PayloadFile -Mapping $mapping
+}
+
+foreach ($name in $metadataFiles) {
+    $sourcePath = Join-Path $BuildDirectory $name
+    if (-not (Test-Path $sourcePath -PathType Leaf)) {
+        throw "Required package metadata '$name' is missing from '$BuildDirectory'."
+    }
+    Copy-Item -Path $sourcePath -Destination (Join-Path $DestinationDirectory $name) -Force
+}
+
+$unexpectedServerFiles = Get-ChildItem -Path $DestinationDirectory -Recurse -File |
+    Where-Object { $serverOnlyNames -contains $_.Name }
+if ($unexpectedServerFiles) {
+    throw "Server-only files were included: $($unexpectedServerFiles.Name -join ', ')."
+}
+
+$baselineDisposition = @()
+foreach ($mapping in $clientFiles) {
+    $baselineDisposition += [ordered]@{
+        path = $mapping.Destination
+        disposition = 'replace'
+        artifactPath = $mapping.Destination
+    }
+}
+$baselineDisposition += [ordered]@{
+    path = 'usr/lib/ssh/ssh-keysign.exe'
+    disposition = 'remove'
+    reason = 'Win32 OpenSSH does not build ssh-keysign; Windows host-based authentication is unsupported.'
+}
+
+$manifest = [ordered]@{
+    schemaVersion = 1
+    artifact = 'OpenSSH-ARM64-Client'
+    architecture = 'arm64'
+    machine = '0xAA64'
+    source = [ordered]@{
+        repository = $SourceRepository
+        ref = $SourceRef
+        revision = $SourceRevision.ToLowerInvariant()
+        vcpkgBaseline = $VcpkgBaseline.ToLowerInvariant()
+    }
+    build = [ordered]@{
+        repository = $BuildRepository
+        revision = $BuildRevision
+        run = $BuildRun
+    }
+    files = $manifestFiles
+    baselineDisposition = $baselineDisposition
+}
+
+$manifestPath = Join-Path $DestinationDirectory 'manifest.json'
+$manifest | ConvertTo-Json -Depth 8 | Set-Content -Path $manifestPath -Encoding UTF8
+
+Write-Host "Created ARM64 client package at '$DestinationDirectory' with $($manifestFiles.Count) PE files."

--- a/tests/Invoke-OpenSSHClientSmoke.ps1
+++ b/tests/Invoke-OpenSSHClientSmoke.ps1
@@ -122,6 +122,9 @@ $sshdServiceWasRunning = $false
 $sshdPrivilegesExisted = $false
 $sshdRequiredPrivileges = $null
 $sshdLog = $null
+$openSshRegistryKeyExisted = $false
+$defaultShellExisted = $false
+$defaultShell = $null
 $succeeded = $false
 $oldGitSsh = $env:GIT_SSH
 $oldGitSshVariant = $env:GIT_SSH_VARIANT
@@ -177,6 +180,16 @@ try {
     ) | Set-Content -Path $sshdConfig -Encoding ascii
 
     Invoke-Checked -FilePath $sshd -ArgumentList @('-t', '-f', $sshdConfig)
+    $openSshRegistryPath = 'HKLM:\SOFTWARE\OpenSSH'
+    $openSshRegistryKeyExisted = Test-Path $openSshRegistryPath
+    $null = New-Item -Path $openSshRegistryPath -Force
+    $openSshRegistry = Get-ItemProperty -Path $openSshRegistryPath
+    if ($openSshRegistry.PSObject.Properties.Name -contains 'DefaultShell') {
+        $defaultShellExisted = $true
+        $defaultShell = $openSshRegistry.DefaultShell
+    }
+    Set-ItemProperty -Path $openSshRegistryPath -Name DefaultShell -Value (Join-Path $PSHOME 'powershell.exe')
+
     $sshdService = Get-CimInstance Win32_Service -Filter "Name='sshd'" -ErrorAction SilentlyContinue
     if ($sshdService) {
         $sshdServicePath = $sshdService.PathName
@@ -428,6 +441,17 @@ finally {
         if ($sshdServiceWasRunning) {
             Start-Service -Name sshd
         }
+    }
+
+    $openSshRegistryPath = 'HKLM:\SOFTWARE\OpenSSH'
+    if ($defaultShellExisted) {
+        Set-ItemProperty -Path $openSshRegistryPath -Name DefaultShell -Value $defaultShell
+    }
+    else {
+        Remove-ItemProperty -Path $openSshRegistryPath -Name DefaultShell -ErrorAction SilentlyContinue
+    }
+    if (-not $openSshRegistryKeyExisted) {
+        Remove-Item -Path $openSshRegistryPath -Force -ErrorAction SilentlyContinue
     }
 
     if (-not $succeeded -and $sshdLog -and (Test-Path $sshdLog) -and $env:GITHUB_WORKSPACE) {

--- a/tests/Invoke-OpenSSHClientSmoke.ps1
+++ b/tests/Invoke-OpenSSHClientSmoke.ps1
@@ -70,6 +70,32 @@ function Convert-ToSshPath {
     return ([System.IO.Path]::GetFullPath($Path)).Replace('\', '/')
 }
 
+function Set-PrivateKeyAcl {
+    param(
+        [Parameter(Mandatory)]
+        [string] $Path,
+
+        [Parameter(Mandatory)]
+        [System.Security.Principal.SecurityIdentifier] $Owner,
+
+        [Parameter(Mandatory)]
+        [System.Security.Principal.SecurityIdentifier[]] $FullControl
+    )
+
+    $acl = [System.Security.AccessControl.FileSecurity]::new()
+    $acl.SetOwner($Owner)
+    $acl.SetAccessRuleProtection($true, $false)
+    foreach ($identity in $FullControl) {
+        $rule = [System.Security.AccessControl.FileSystemAccessRule]::new(
+            $identity,
+            [System.Security.AccessControl.FileSystemRights]::FullControl,
+            [System.Security.AccessControl.AccessControlType]::Allow
+        )
+        $null = $acl.AddAccessRule($rule)
+    }
+    Set-Acl -Path $Path -AclObject $acl
+}
+
 $tempBase = if ($env:RUNNER_TEMP) { $env:RUNNER_TEMP } else { [System.IO.Path]::GetTempPath() }
 $testRoot = Join-Path $tempBase "openssh-arm64-client-$PID"
 $profileSshDirectory = Join-Path $env:USERPROFILE '.ssh'
@@ -112,21 +138,12 @@ try {
     Invoke-Checked -FilePath $sshKeygen -ArgumentList @('-q', '-t', 'rsa', '-b', '3072', '-N', '""', '-f', $rsaKey)
     Invoke-Checked -FilePath $sshKeygen -ArgumentList @('-lf', "$rsaKey.pub")
 
-    Invoke-Checked -FilePath 'icacls.exe' -ArgumentList @(
-        $hostKey,
-        '/inheritance:r',
-        '/grant:r',
-        '*S-1-5-18:(F)',
-        '*S-1-5-32-544:(F)'
-    )
-    $userSid = [System.Security.Principal.WindowsIdentity]::GetCurrent().User.Value
+    $systemSid = [System.Security.Principal.SecurityIdentifier]::new('S-1-5-18')
+    $administratorsSid = [System.Security.Principal.SecurityIdentifier]::new('S-1-5-32-544')
+    $userSid = [System.Security.Principal.WindowsIdentity]::GetCurrent().User
+    Set-PrivateKeyAcl -Path $hostKey -Owner $administratorsSid -FullControl @($systemSid, $administratorsSid)
     foreach ($privateKey in @($clientKey, $rsaKey)) {
-        Invoke-Checked -FilePath 'icacls.exe' -ArgumentList @(
-            $privateKey,
-            '/inheritance:r',
-            '/grant:r',
-            "*${userSid}:(F)"
-        )
+        Set-PrivateKeyAcl -Path $privateKey -Owner $userSid -FullControl @($userSid)
     }
 
     $authorizedKeys = Join-Path $testRoot 'authorized_keys'

--- a/tests/Invoke-OpenSSHClientSmoke.ps1
+++ b/tests/Invoke-OpenSSHClientSmoke.ps1
@@ -286,14 +286,18 @@ try {
     if (-not ($noPtyOutput -match 'no-pty-ok')) {
         throw 'Non-PTY SSH command did not return expected output.'
     }
-    $ptyMarker = Join-Path $testRoot 'pty-marker.txt'
     $ptyOutput = Invoke-Checked -FilePath $ssh -ArgumentList @(
         '-tt',
         'arm64-local',
-        "cmd /c echo pty-ok > `"$ptyMarker`""
+        'cmd /c echo pty-ok'
     )
-    if (-not (Test-Path $ptyMarker) -or (Get-Content $ptyMarker -Raw).Trim() -ne 'pty-ok') {
-        throw "Forced-PTY SSH command did not create the expected marker.`n$($ptyOutput -join [Environment]::NewLine)"
+    $ptyDeadline = (Get-Date).AddSeconds(5)
+    do {
+        Start-Sleep -Milliseconds 100
+        $sshdLogContent = Get-Content $sshdLog -Raw -ErrorAction SilentlyContinue
+    } while ($sshdLogContent -notmatch 'Starting session: command on windows-pty' -and (Get-Date) -lt $ptyDeadline)
+    if ($sshdLogContent -notmatch 'Starting session: command on windows-pty') {
+        throw "sshd did not record a forced Windows PTY session.`n$($ptyOutput -join [Environment]::NewLine)"
     }
 
     $copySource = Join-Path $testRoot 'scp-source.txt'

--- a/tests/Invoke-OpenSSHClientSmoke.ps1
+++ b/tests/Invoke-OpenSSHClientSmoke.ps1
@@ -105,9 +105,11 @@ try {
     $hostKey = Join-Path $testRoot 'ssh_host_ed25519_key'
     $clientKey = Join-Path $testRoot 'id_ed25519'
     $rsaKey = Join-Path $testRoot 'id_rsa'
-    Invoke-Checked -FilePath $sshKeygen -ArgumentList @('-q', '-t', 'ed25519', '-N', '', '-f', $hostKey)
-    Invoke-Checked -FilePath $sshKeygen -ArgumentList @('-q', '-t', 'ed25519', '-N', '', '-f', $clientKey)
-    Invoke-Checked -FilePath $sshKeygen -ArgumentList @('-q', '-t', 'rsa', '-b', '3072', '-N', '', '-f', $rsaKey)
+    # Windows PowerShell 5.1 drops empty native arguments, so preserve the
+    # explicit empty passphrase through CommandLineToArgvW.
+    Invoke-Checked -FilePath $sshKeygen -ArgumentList @('-q', '-t', 'ed25519', '-N', '""', '-f', $hostKey)
+    Invoke-Checked -FilePath $sshKeygen -ArgumentList @('-q', '-t', 'ed25519', '-N', '""', '-f', $clientKey)
+    Invoke-Checked -FilePath $sshKeygen -ArgumentList @('-q', '-t', 'rsa', '-b', '3072', '-N', '""', '-f', $rsaKey)
     Invoke-Checked -FilePath $sshKeygen -ArgumentList @('-lf', "$rsaKey.pub")
 
     $authorizedKeys = Join-Path $testRoot 'authorized_keys'

--- a/tests/Invoke-OpenSSHClientSmoke.ps1
+++ b/tests/Invoke-OpenSSHClientSmoke.ps1
@@ -112,6 +112,23 @@ try {
     Invoke-Checked -FilePath $sshKeygen -ArgumentList @('-q', '-t', 'rsa', '-b', '3072', '-N', '""', '-f', $rsaKey)
     Invoke-Checked -FilePath $sshKeygen -ArgumentList @('-lf', "$rsaKey.pub")
 
+    Invoke-Checked -FilePath 'icacls.exe' -ArgumentList @(
+        $hostKey,
+        '/inheritance:r',
+        '/grant:r',
+        '*S-1-5-18:(F)',
+        '*S-1-5-32-544:(F)'
+    )
+    $userSid = [System.Security.Principal.WindowsIdentity]::GetCurrent().User.Value
+    foreach ($privateKey in @($clientKey, $rsaKey)) {
+        Invoke-Checked -FilePath 'icacls.exe' -ArgumentList @(
+            $privateKey,
+            '/inheritance:r',
+            '/grant:r',
+            "*${userSid}:(F)"
+        )
+    }
+
     $authorizedKeys = Join-Path $testRoot 'authorized_keys'
     Copy-Item "$clientKey.pub" $authorizedKeys -Force
     $knownHosts = Join-Path $profileSshDirectory 'known_hosts-arm64-client'

--- a/tests/Invoke-OpenSSHClientSmoke.ps1
+++ b/tests/Invoke-OpenSSHClientSmoke.ps1
@@ -184,7 +184,7 @@ try {
     $openSshRegistryKeyExisted = Test-Path $openSshRegistryPath
     $null = New-Item -Path $openSshRegistryPath -Force
     $openSshRegistry = Get-ItemProperty -Path $openSshRegistryPath
-    if ($openSshRegistry.PSObject.Properties.Name -contains 'DefaultShell') {
+    if ($null -ne $openSshRegistry.PSObject.Properties['DefaultShell']) {
         $defaultShellExisted = $true
         $defaultShell = $openSshRegistry.DefaultShell
     }
@@ -198,7 +198,7 @@ try {
         $sshdServiceWasRunning = $sshdService.State -eq 'Running'
         $serviceRegistryPath = 'HKLM:\SYSTEM\CurrentControlSet\Services\sshd'
         $serviceRegistry = Get-ItemProperty -Path $serviceRegistryPath
-        if ($serviceRegistry.PSObject.Properties.Name -contains 'RequiredPrivileges') {
+        if ($null -ne $serviceRegistry.PSObject.Properties['RequiredPrivileges']) {
             $sshdPrivilegesExisted = $true
             $sshdRequiredPrivileges = @($serviceRegistry.RequiredPrivileges)
         }

--- a/tests/Invoke-OpenSSHClientSmoke.ps1
+++ b/tests/Invoke-OpenSSHClientSmoke.ps1
@@ -152,18 +152,24 @@ try {
         Invoke-Checked -FilePath 'sc.exe' -ArgumentList @(
             'config',
             'sshd',
-            "binPath= `"$sshd`" -f `"$sshdConfig`" -E `"$sshdLog`"",
-            'start= demand',
-            'obj= LocalSystem'
+            'binPath=',
+            "`"$sshd`" -f `"$sshdConfig`" -E `"$sshdLog`"",
+            'start=',
+            'demand',
+            'obj=',
+            'LocalSystem'
         )
     }
     else {
         Invoke-Checked -FilePath 'sc.exe' -ArgumentList @(
             'create',
             'sshd',
-            "binPath= `"$sshd`" -f `"$sshdConfig`" -E `"$sshdLog`"",
-            'start= demand',
-            'obj= LocalSystem'
+            'binPath=',
+            "`"$sshd`" -f `"$sshdConfig`" -E `"$sshdLog`"",
+            'start=',
+            'demand',
+            'obj=',
+            'LocalSystem'
         )
         $sshdServiceCreated = $true
     }
@@ -272,10 +278,24 @@ try {
         $agentServiceStartMode = $agentService.StartMode
         $agentServiceWasRunning = $agentService.State -eq 'Running'
         Stop-Service -Name ssh-agent -Force -ErrorAction SilentlyContinue
-        Invoke-Checked -FilePath 'sc.exe' -ArgumentList @('config', 'ssh-agent', "binPath= `"$sshAgent`"", 'start= demand')
+        Invoke-Checked -FilePath 'sc.exe' -ArgumentList @(
+            'config',
+            'ssh-agent',
+            'binPath=',
+            "`"$sshAgent`"",
+            'start=',
+            'demand'
+        )
     }
     else {
-        Invoke-Checked -FilePath 'sc.exe' -ArgumentList @('create', 'ssh-agent', "binPath= `"$sshAgent`"", 'start= demand')
+        Invoke-Checked -FilePath 'sc.exe' -ArgumentList @(
+            'create',
+            'ssh-agent',
+            'binPath=',
+            "`"$sshAgent`"",
+            'start=',
+            'demand'
+        )
         $agentServiceCreated = $true
     }
     Start-Service -Name ssh-agent
@@ -326,11 +346,11 @@ finally {
         & sc.exe delete ssh-agent | Out-Null
     }
     elseif ($agentService) {
-        & sc.exe config ssh-agent "binPath= $agentServicePath" | Out-Null
+        & sc.exe config ssh-agent 'binPath=' $agentServicePath | Out-Null
         switch ($agentServiceStartMode) {
-            'Auto' { & sc.exe config ssh-agent 'start= auto' | Out-Null }
-            'Manual' { & sc.exe config ssh-agent 'start= demand' | Out-Null }
-            'Disabled' { & sc.exe config ssh-agent 'start= disabled' | Out-Null }
+            'Auto' { & sc.exe config ssh-agent 'start=' 'auto' | Out-Null }
+            'Manual' { & sc.exe config ssh-agent 'start=' 'demand' | Out-Null }
+            'Disabled' { & sc.exe config ssh-agent 'start=' 'disabled' | Out-Null }
         }
         if ($agentServiceWasRunning) {
             Start-Service -Name ssh-agent
@@ -342,11 +362,11 @@ finally {
         & sc.exe delete sshd | Out-Null
     }
     elseif ($sshdService) {
-        & sc.exe config sshd "binPath= $sshdServicePath" "obj= $sshdServiceStartName" | Out-Null
+        & sc.exe config sshd 'binPath=' $sshdServicePath 'obj=' $sshdServiceStartName | Out-Null
         switch ($sshdServiceStartMode) {
-            'Auto' { & sc.exe config sshd 'start= auto' | Out-Null }
-            'Manual' { & sc.exe config sshd 'start= demand' | Out-Null }
-            'Disabled' { & sc.exe config sshd 'start= disabled' | Out-Null }
+            'Auto' { & sc.exe config sshd 'start=' 'auto' | Out-Null }
+            'Manual' { & sc.exe config sshd 'start=' 'demand' | Out-Null }
+            'Disabled' { & sc.exe config sshd 'start=' 'disabled' | Out-Null }
         }
         $serviceRegistryPath = 'HKLM:\SYSTEM\CurrentControlSet\Services\sshd'
         if ($sshdPrivilegesExisted) {

--- a/tests/Invoke-OpenSSHClientSmoke.ps1
+++ b/tests/Invoke-OpenSSHClientSmoke.ps1
@@ -286,9 +286,14 @@ try {
     if (-not ($noPtyOutput -match 'no-pty-ok')) {
         throw 'Non-PTY SSH command did not return expected output.'
     }
-    $ptyOutput = Invoke-Checked -FilePath $ssh -ArgumentList @('-tt', 'arm64-local', 'cmd /c echo pty-ok')
-    if (-not ($ptyOutput -match 'pty-ok')) {
-        throw 'Forced-PTY SSH command did not return expected output.'
+    $ptyMarker = Join-Path $testRoot 'pty-marker.txt'
+    $ptyOutput = Invoke-Checked -FilePath $ssh -ArgumentList @(
+        '-tt',
+        'arm64-local',
+        "cmd /c echo pty-ok > `"$ptyMarker`""
+    )
+    if (-not (Test-Path $ptyMarker) -or (Get-Content $ptyMarker -Raw).Trim() -ne 'pty-ok') {
+        throw "Forced-PTY SSH command did not create the expected marker.`n$($ptyOutput -join [Environment]::NewLine)"
     }
 
     $copySource = Join-Path $testRoot 'scp-source.txt'

--- a/tests/Invoke-OpenSSHClientSmoke.ps1
+++ b/tests/Invoke-OpenSSHClientSmoke.ps1
@@ -40,14 +40,21 @@ function Invoke-Checked {
     if ($WorkingDirectory) {
         Push-Location $WorkingDirectory
     }
+    $previousErrorActionPreference = $ErrorActionPreference
     try {
+        # Windows PowerShell 5.1 wraps native stderr as error records. Capture
+        # diagnostics without treating warnings as failures; the exit code is
+        # authoritative for these tools.
+        $ErrorActionPreference = 'Continue'
         $output = @(& $FilePath @ArgumentList 2>&1 | ForEach-Object { $_.ToString() })
-        if ($LASTEXITCODE -ne 0) {
-            throw "'$FilePath $($ArgumentList -join ' ')' failed with exit code $LASTEXITCODE.`n$($output -join [Environment]::NewLine)"
+        $exitCode = $LASTEXITCODE
+        if ($exitCode -ne 0) {
+            throw "'$FilePath $($ArgumentList -join ' ')' failed with exit code $exitCode.`n$($output -join [Environment]::NewLine)"
         }
         return $output
     }
     finally {
+        $ErrorActionPreference = $previousErrorActionPreference
         if ($WorkingDirectory) {
             Pop-Location
         }

--- a/tests/Invoke-OpenSSHClientSmoke.ps1
+++ b/tests/Invoke-OpenSSHClientSmoke.ps1
@@ -1,0 +1,375 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)]
+    [ValidateScript({ Test-Path $_ -PathType Container })]
+    [string] $BuildDirectory,
+
+    [string] $GitExecutable = 'git.exe'
+)
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version 2.0
+
+$ssh = Join-Path $BuildDirectory 'ssh.exe'
+$sshd = Join-Path $BuildDirectory 'sshd.exe'
+$sshAdd = Join-Path $BuildDirectory 'ssh-add.exe'
+$sshAgent = Join-Path $BuildDirectory 'ssh-agent.exe'
+$sshKeygen = Join-Path $BuildDirectory 'ssh-keygen.exe'
+$sshKeyscan = Join-Path $BuildDirectory 'ssh-keyscan.exe'
+$scp = Join-Path $BuildDirectory 'scp.exe'
+$sftp = Join-Path $BuildDirectory 'sftp.exe'
+$sftpServer = Join-Path $BuildDirectory 'sftp-server.exe'
+
+foreach ($path in @($ssh, $sshd, $sshAdd, $sshAgent, $sshKeygen, $sshKeyscan, $scp, $sftp, $sftpServer)) {
+    if (-not (Test-Path $path -PathType Leaf)) {
+        throw "Required smoke-test binary '$path' is missing."
+    }
+}
+
+function Invoke-Checked {
+    param(
+        [Parameter(Mandatory)]
+        [string] $FilePath,
+
+        [Parameter()]
+        [string[]] $ArgumentList = @(),
+
+        [string] $WorkingDirectory = ''
+    )
+
+    if ($WorkingDirectory) {
+        Push-Location $WorkingDirectory
+    }
+    try {
+        $output = @(& $FilePath @ArgumentList 2>&1 | ForEach-Object { $_.ToString() })
+        if ($LASTEXITCODE -ne 0) {
+            throw "'$FilePath $($ArgumentList -join ' ')' failed with exit code $LASTEXITCODE.`n$($output -join [Environment]::NewLine)"
+        }
+        return $output
+    }
+    finally {
+        if ($WorkingDirectory) {
+            Pop-Location
+        }
+    }
+}
+
+function Get-FreeTcpPort {
+    $listener = [System.Net.Sockets.TcpListener]::new([System.Net.IPAddress]::Loopback, 0)
+    $listener.Start()
+    try {
+        return ([System.Net.IPEndPoint] $listener.LocalEndpoint).Port
+    }
+    finally {
+        $listener.Stop()
+    }
+}
+
+function Convert-ToSshPath {
+    param([Parameter(Mandatory)][string] $Path)
+    return ([System.IO.Path]::GetFullPath($Path)).Replace('\', '/')
+}
+
+$tempBase = if ($env:RUNNER_TEMP) { $env:RUNNER_TEMP } else { [System.IO.Path]::GetTempPath() }
+$testRoot = Join-Path $tempBase "openssh-arm64-client-$PID"
+$profileSshDirectory = Join-Path $env:USERPROFILE '.ssh'
+$profileConfig = Join-Path $profileSshDirectory 'config'
+$profileConfigBackup = $null
+$agentService = $null
+$agentServiceCreated = $false
+$agentServicePath = $null
+$agentServiceStartMode = $null
+$agentServiceWasRunning = $false
+$sshdService = $null
+$sshdServiceCreated = $false
+$sshdServicePath = $null
+$sshdServiceStartMode = $null
+$sshdServiceStartName = $null
+$sshdServiceWasRunning = $false
+$sshdPrivilegesExisted = $false
+$sshdRequiredPrivileges = $null
+$sshdLog = $null
+$succeeded = $false
+$oldGitSsh = $env:GIT_SSH
+$oldGitSshVariant = $env:GIT_SSH_VARIANT
+
+try {
+    $null = New-Item -ItemType Directory -Path $testRoot -Force
+    $null = New-Item -ItemType Directory -Path $profileSshDirectory -Force
+
+    if (Test-Path $profileConfig -PathType Leaf) {
+        $profileConfigBackup = Join-Path $testRoot 'profile-config.backup'
+        Copy-Item $profileConfig $profileConfigBackup -Force
+    }
+
+    $hostKey = Join-Path $testRoot 'ssh_host_ed25519_key'
+    $clientKey = Join-Path $testRoot 'id_ed25519'
+    $rsaKey = Join-Path $testRoot 'id_rsa'
+    Invoke-Checked -FilePath $sshKeygen -ArgumentList @('-q', '-t', 'ed25519', '-N', '', '-f', $hostKey)
+    Invoke-Checked -FilePath $sshKeygen -ArgumentList @('-q', '-t', 'ed25519', '-N', '', '-f', $clientKey)
+    Invoke-Checked -FilePath $sshKeygen -ArgumentList @('-q', '-t', 'rsa', '-b', '3072', '-N', '', '-f', $rsaKey)
+    Invoke-Checked -FilePath $sshKeygen -ArgumentList @('-lf', "$rsaKey.pub")
+
+    $authorizedKeys = Join-Path $testRoot 'authorized_keys'
+    Copy-Item "$clientKey.pub" $authorizedKeys -Force
+    $knownHosts = Join-Path $profileSshDirectory 'known_hosts-arm64-client'
+    $port = Get-FreeTcpPort
+    $sshdConfig = Join-Path $testRoot 'sshd_config'
+    $sshdLog = Join-Path $testRoot 'sshd.log'
+
+    @(
+        "Port $port"
+        'ListenAddress 127.0.0.1'
+        "HostKey `"$hostKey`""
+        "AuthorizedKeysFile `"$authorizedKeys`""
+        'PubkeyAuthentication yes'
+        'PasswordAuthentication no'
+        'KbdInteractiveAuthentication no'
+        'StrictModes no'
+        'AllowTcpForwarding yes'
+        'PermitTTY yes'
+        "PidFile `"$testRoot\sshd.pid`""
+        "Subsystem sftp `"$sftpServer`""
+        'LogLevel VERBOSE'
+    ) | Set-Content -Path $sshdConfig -Encoding ascii
+
+    Invoke-Checked -FilePath $sshd -ArgumentList @('-t', '-f', $sshdConfig)
+    $sshdService = Get-CimInstance Win32_Service -Filter "Name='sshd'" -ErrorAction SilentlyContinue
+    if ($sshdService) {
+        $sshdServicePath = $sshdService.PathName
+        $sshdServiceStartMode = $sshdService.StartMode
+        $sshdServiceStartName = $sshdService.StartName
+        $sshdServiceWasRunning = $sshdService.State -eq 'Running'
+        $serviceRegistryPath = 'HKLM:\SYSTEM\CurrentControlSet\Services\sshd'
+        $serviceRegistry = Get-ItemProperty -Path $serviceRegistryPath
+        if ($serviceRegistry.PSObject.Properties.Name -contains 'RequiredPrivileges') {
+            $sshdPrivilegesExisted = $true
+            $sshdRequiredPrivileges = @($serviceRegistry.RequiredPrivileges)
+        }
+        Stop-Service -Name sshd -Force -ErrorAction SilentlyContinue
+        Invoke-Checked -FilePath 'sc.exe' -ArgumentList @(
+            'config',
+            'sshd',
+            "binPath= `"$sshd`" -f `"$sshdConfig`" -E `"$sshdLog`"",
+            'start= demand',
+            'obj= LocalSystem'
+        )
+    }
+    else {
+        Invoke-Checked -FilePath 'sc.exe' -ArgumentList @(
+            'create',
+            'sshd',
+            "binPath= `"$sshd`" -f `"$sshdConfig`" -E `"$sshdLog`"",
+            'start= demand',
+            'obj= LocalSystem'
+        )
+        $sshdServiceCreated = $true
+    }
+    Invoke-Checked -FilePath 'sc.exe' -ArgumentList @(
+        'privs',
+        'sshd',
+        'SeAssignPrimaryTokenPrivilege/SeTcbPrivilege/SeBackupPrivilege/SeRestorePrivilege/SeImpersonatePrivilege'
+    )
+    Start-Service -Name sshd
+
+    $deadline = (Get-Date).AddSeconds(30)
+    $listening = $false
+    do {
+        if ((Get-Service -Name sshd).Status -eq 'Stopped') {
+            throw "sshd exited before accepting connections.`n$(Get-Content $sshdLog -Raw -ErrorAction SilentlyContinue)"
+        }
+        Start-Sleep -Milliseconds 250
+        $client = New-Object System.Net.Sockets.TcpClient
+        try {
+            $connect = $client.BeginConnect('127.0.0.1', $port, $null, $null)
+            $listening = $connect.AsyncWaitHandle.WaitOne(250) -and $client.Connected
+        }
+        finally {
+            $client.Dispose()
+        }
+    } while (-not $listening -and (Get-Date) -lt $deadline)
+    if (-not $listening) {
+        throw "sshd did not listen on port $port."
+    }
+
+    $keyscanOutput = Invoke-Checked -FilePath $sshKeyscan -ArgumentList @('-p', "$port", '127.0.0.1')
+    $keyscanOutput | Where-Object { $_ -and -not $_.StartsWith('#') } |
+        Set-Content -Path $knownHosts -Encoding ascii
+
+    @(
+        'Host arm64-local'
+        '    HostName 127.0.0.1'
+        "    Port $port"
+        "    User $env:USERNAME"
+        "    IdentityFile `"$clientKey`""
+        '    IdentitiesOnly yes'
+        "    UserKnownHostsFile `"$knownHosts`""
+        '    StrictHostKeyChecking yes'
+        '    BatchMode yes'
+        ''
+        'Host arm64-proxy'
+        '    HostName 127.0.0.1'
+        "    Port $port"
+        "    User $env:USERNAME"
+        "    IdentityFile `"$clientKey`""
+        '    IdentitiesOnly yes'
+        "    UserKnownHostsFile `"$knownHosts`""
+        '    StrictHostKeyChecking yes'
+        '    BatchMode yes'
+        "    ProxyCommand `"$ssh`" -F `"$profileConfig`" -W %h:%p arm64-local"
+    ) | Set-Content -Path $profileConfig -Encoding ascii
+
+    $resolvedConfig = Invoke-Checked -FilePath $ssh -ArgumentList @('-G', 'arm64-local')
+    if (-not ($resolvedConfig -match "^port $port$")) {
+        throw 'OpenSSH did not discover the user config file.'
+    }
+
+    $directOutput = Invoke-Checked -FilePath $ssh -ArgumentList @('-T', 'arm64-local', 'cmd /c echo ssh-direct-ok')
+    if (-not ($directOutput -match 'ssh-direct-ok')) {
+        throw 'Direct SSH command did not return expected output.'
+    }
+    $proxyOutput = Invoke-Checked -FilePath $ssh -ArgumentList @('-T', 'arm64-proxy', 'cmd /c echo ssh-proxy-ok')
+    if (-not ($proxyOutput -match 'ssh-proxy-ok')) {
+        throw 'ProxyCommand SSH command did not return expected output.'
+    }
+
+    $noPtyOutput = Invoke-Checked -FilePath $ssh -ArgumentList @('-T', 'arm64-local', 'cmd /c echo no-pty-ok')
+    if (-not ($noPtyOutput -match 'no-pty-ok')) {
+        throw 'Non-PTY SSH command did not return expected output.'
+    }
+    $ptyOutput = Invoke-Checked -FilePath $ssh -ArgumentList @('-tt', 'arm64-local', 'cmd /c echo pty-ok')
+    if (-not ($ptyOutput -match 'pty-ok')) {
+        throw 'Forced-PTY SSH command did not return expected output.'
+    }
+
+    $copySource = Join-Path $testRoot 'scp-source.txt'
+    $copyRemote = Join-Path $testRoot 'scp-remote.txt'
+    'scp-arm64-ok' | Set-Content -Path $copySource -Encoding ascii
+    Invoke-Checked -FilePath $scp -ArgumentList @($copySource, "arm64-local:$(Convert-ToSshPath $copyRemote)")
+    if ((Get-Content $copyRemote -Raw).Trim() -ne 'scp-arm64-ok') {
+        throw 'scp content verification failed.'
+    }
+
+    $sftpSource = Join-Path $testRoot 'sftp-source.txt'
+    $sftpRemote = Join-Path $testRoot 'sftp-remote.txt'
+    $sftpDownloaded = Join-Path $testRoot 'sftp-downloaded.txt'
+    $sftpBatch = Join-Path $testRoot 'sftp.batch'
+    'sftp-arm64-ok' | Set-Content -Path $sftpSource -Encoding ascii
+    @(
+        "put `"$(Convert-ToSshPath $sftpSource)`" `"$(Convert-ToSshPath $sftpRemote)`""
+        "get `"$(Convert-ToSshPath $sftpRemote)`" `"$(Convert-ToSshPath $sftpDownloaded)`""
+    ) | Set-Content -Path $sftpBatch -Encoding ascii
+    Invoke-Checked -FilePath $sftp -ArgumentList @('-b', $sftpBatch, 'arm64-local')
+    if ((Get-Content $sftpDownloaded -Raw).Trim() -ne 'sftp-arm64-ok') {
+        throw 'sftp content verification failed.'
+    }
+
+    $agentService = Get-CimInstance Win32_Service -Filter "Name='ssh-agent'" -ErrorAction SilentlyContinue
+    if ($agentService) {
+        $agentServicePath = $agentService.PathName
+        $agentServiceStartMode = $agentService.StartMode
+        $agentServiceWasRunning = $agentService.State -eq 'Running'
+        Stop-Service -Name ssh-agent -Force -ErrorAction SilentlyContinue
+        Invoke-Checked -FilePath 'sc.exe' -ArgumentList @('config', 'ssh-agent', "binPath= `"$sshAgent`"", 'start= demand')
+    }
+    else {
+        Invoke-Checked -FilePath 'sc.exe' -ArgumentList @('create', 'ssh-agent', "binPath= `"$sshAgent`"", 'start= demand')
+        $agentServiceCreated = $true
+    }
+    Start-Service -Name ssh-agent
+    Invoke-Checked -FilePath $sshAdd -ArgumentList @($clientKey)
+    $agentKeys = Invoke-Checked -FilePath $sshAdd -ArgumentList @('-l')
+    if (-not ($agentKeys -match 'ED25519')) {
+        throw 'ssh-agent did not retain the ED25519 key.'
+    }
+    Invoke-Checked -FilePath $sshAdd -ArgumentList @('-D')
+
+    $seedRepository = Join-Path $testRoot 'seed'
+    $remoteRepository = Join-Path $testRoot 'remote.git'
+    $cloneRepository = Join-Path $testRoot 'clone'
+    Invoke-Checked -FilePath $GitExecutable -ArgumentList @('init', '-b', 'main', $seedRepository)
+    Invoke-Checked -FilePath $GitExecutable -ArgumentList @('-C', $seedRepository, 'config', 'user.name', 'ARM64 OpenSSH CI')
+    Invoke-Checked -FilePath $GitExecutable -ArgumentList @('-C', $seedRepository, 'config', 'user.email', 'arm64-openssh-ci@example.invalid')
+    'first' | Set-Content -Path (Join-Path $seedRepository 'payload.txt') -Encoding ascii
+    Invoke-Checked -FilePath $GitExecutable -ArgumentList @('-C', $seedRepository, 'add', 'payload.txt')
+    Invoke-Checked -FilePath $GitExecutable -ArgumentList @('-C', $seedRepository, 'commit', '-m', 'initial')
+    Invoke-Checked -FilePath $GitExecutable -ArgumentList @('init', '--bare', $remoteRepository)
+    Invoke-Checked -FilePath $GitExecutable -ArgumentList @('-C', $seedRepository, 'remote', 'add', 'origin', $remoteRepository)
+    Invoke-Checked -FilePath $GitExecutable -ArgumentList @('-C', $seedRepository, 'push', '-u', 'origin', 'main')
+
+    $env:GIT_SSH = $ssh
+    $env:GIT_SSH_VARIANT = 'ssh'
+    $remoteSshUrl = "arm64-local:$(Convert-ToSshPath $remoteRepository)"
+    Invoke-Checked -FilePath $GitExecutable -ArgumentList @('clone', $remoteSshUrl, $cloneRepository)
+
+    'second' | Set-Content -Path (Join-Path $seedRepository 'payload.txt') -Encoding ascii
+    Invoke-Checked -FilePath $GitExecutable -ArgumentList @('-C', $seedRepository, 'add', 'payload.txt')
+    Invoke-Checked -FilePath $GitExecutable -ArgumentList @('-C', $seedRepository, 'commit', '-m', 'update')
+    Invoke-Checked -FilePath $GitExecutable -ArgumentList @('-C', $seedRepository, 'push')
+    Invoke-Checked -FilePath $GitExecutable -ArgumentList @('-C', $cloneRepository, 'fetch', 'origin')
+    $fetchedSubject = Invoke-Checked -FilePath $GitExecutable -ArgumentList @('-C', $cloneRepository, 'log', '-1', '--format=%s', 'origin/main')
+    if ($fetchedSubject -ne 'update') {
+        throw 'Git-over-SSH fetch did not receive the updated commit.'
+    }
+
+    $succeeded = $true
+    Write-Host 'Passed ARM64 OpenSSH client smoke tests: keys, config, known_hosts, ProxyCommand, agent, scp, sftp, PTY, and Git clone/fetch.'
+}
+finally {
+    $env:GIT_SSH = $oldGitSsh
+    $env:GIT_SSH_VARIANT = $oldGitSshVariant
+
+    Stop-Service -Name ssh-agent -Force -ErrorAction SilentlyContinue
+    if ($agentServiceCreated) {
+        & sc.exe delete ssh-agent | Out-Null
+    }
+    elseif ($agentService) {
+        & sc.exe config ssh-agent "binPath= $agentServicePath" | Out-Null
+        switch ($agentServiceStartMode) {
+            'Auto' { & sc.exe config ssh-agent 'start= auto' | Out-Null }
+            'Manual' { & sc.exe config ssh-agent 'start= demand' | Out-Null }
+            'Disabled' { & sc.exe config ssh-agent 'start= disabled' | Out-Null }
+        }
+        if ($agentServiceWasRunning) {
+            Start-Service -Name ssh-agent
+        }
+    }
+
+    Stop-Service -Name sshd -Force -ErrorAction SilentlyContinue
+    if ($sshdServiceCreated) {
+        & sc.exe delete sshd | Out-Null
+    }
+    elseif ($sshdService) {
+        & sc.exe config sshd "binPath= $sshdServicePath" "obj= $sshdServiceStartName" | Out-Null
+        switch ($sshdServiceStartMode) {
+            'Auto' { & sc.exe config sshd 'start= auto' | Out-Null }
+            'Manual' { & sc.exe config sshd 'start= demand' | Out-Null }
+            'Disabled' { & sc.exe config sshd 'start= disabled' | Out-Null }
+        }
+        $serviceRegistryPath = 'HKLM:\SYSTEM\CurrentControlSet\Services\sshd'
+        if ($sshdPrivilegesExisted) {
+            Set-ItemProperty -Path $serviceRegistryPath -Name RequiredPrivileges -Value $sshdRequiredPrivileges
+        }
+        else {
+            Remove-ItemProperty -Path $serviceRegistryPath -Name RequiredPrivileges -ErrorAction SilentlyContinue
+        }
+        if ($sshdServiceWasRunning) {
+            Start-Service -Name sshd
+        }
+    }
+
+    if (-not $succeeded -and $sshdLog -and (Test-Path $sshdLog) -and $env:GITHUB_WORKSPACE) {
+        $smokeLogDirectory = Join-Path $env:GITHUB_WORKSPACE 'smoke-logs'
+        $null = New-Item -ItemType Directory -Path $smokeLogDirectory -Force
+        Copy-Item $sshdLog (Join-Path $smokeLogDirectory 'sshd.log') -Force
+    }
+
+    if ($profileConfigBackup) {
+        Copy-Item $profileConfigBackup $profileConfig -Force
+    }
+    else {
+        Remove-Item $profileConfig -Force -ErrorAction SilentlyContinue
+    }
+    Remove-Item (Join-Path $profileSshDirectory 'known_hosts-arm64-client') -Force -ErrorAction SilentlyContinue
+    Remove-Item $testRoot -Recurse -Force -ErrorAction SilentlyContinue
+}

--- a/tests/Invoke-OpenSSHUnitTests.ps1
+++ b/tests/Invoke-OpenSSHUnitTests.ps1
@@ -1,0 +1,43 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)]
+    [ValidateScript({ Test-Path $_ -PathType Container })]
+    [string] $BuildDirectory
+)
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version 2.0
+
+$expectedTests = @(
+    'unittest-bitmap.exe',
+    'unittest-hostkeys.exe',
+    'unittest-kex.exe',
+    'unittest-match.exe',
+    'unittest-misc.exe',
+    'unittest-sshbuf.exe',
+    'unittest-sshkey.exe',
+    'unittest-win32compat.exe'
+)
+$testExecutables = @(Get-ChildItem -Path $BuildDirectory -Recurse -File -Filter 'unittest-*.exe' |
+    Sort-Object Name)
+$actualNames = @($testExecutables | ForEach-Object Name)
+$missingTests = @($expectedTests | Where-Object { $_ -notin $actualNames })
+if ($missingTests) {
+    throw "Missing upstream unit test executables under '$BuildDirectory': $($missingTests -join ', ')."
+}
+
+foreach ($testExecutable in $testExecutables) {
+    Write-Host "Running $($testExecutable.Name)"
+    Push-Location $testExecutable.DirectoryName
+    try {
+        & $testExecutable.FullName
+        if ($LASTEXITCODE -ne 0) {
+            throw "'$($testExecutable.FullName)' failed with exit code $LASTEXITCODE."
+        }
+    }
+    finally {
+        Pop-Location
+    }
+}
+
+Write-Host "Passed all $($expectedTests.Count) upstream OpenSSH unit test executables."

--- a/tests/Test-OpenSSHClientPackage.ps1
+++ b/tests/Test-OpenSSHClientPackage.ps1
@@ -1,0 +1,112 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)]
+    [ValidateScript({ Test-Path $_ -PathType Container })]
+    [string] $PackageDirectory
+)
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version 2.0
+
+$expectedClientPaths = @(
+    'usr/bin/scp.exe',
+    'usr/bin/sftp.exe',
+    'usr/bin/ssh-add.exe',
+    'usr/bin/ssh-agent.exe',
+    'usr/bin/ssh-keygen.exe',
+    'usr/bin/ssh-keyscan.exe',
+    'usr/bin/ssh-pkcs11-helper.exe',
+    'usr/bin/ssh-sk-helper.exe',
+    'usr/bin/ssh.exe',
+    'usr/lib/ssh/sftp-server.exe',
+    'usr/lib/ssh/ssh-pkcs11-helper.exe',
+    'usr/lib/ssh/ssh-sk-helper.exe'
+)
+$serverOnlyNames = @(
+    'sshd.exe',
+    'sshd-auth.exe',
+    'sshd-session.exe',
+    'ssh-shellhost.exe',
+    'install-sshd.ps1',
+    'uninstall-sshd.ps1',
+    'sshd_config_default',
+    'openssh-events.man',
+    'moduli'
+)
+
+function Get-PEMachine {
+    param([Parameter(Mandatory)][string] $Path)
+
+    $stream = [System.IO.File]::OpenRead($Path)
+    try {
+        $reader = New-Object System.IO.BinaryReader($stream)
+        if ($reader.ReadUInt16() -ne 0x5A4D) {
+            throw "'$Path' does not have an MZ header."
+        }
+        $stream.Position = 0x3c
+        $stream.Position = $reader.ReadInt32()
+        if ($reader.ReadUInt32() -ne 0x00004550) {
+            throw "'$Path' does not have a PE signature."
+        }
+        return $reader.ReadUInt16()
+    }
+    finally {
+        $stream.Dispose()
+    }
+}
+
+$manifestPath = Join-Path $PackageDirectory 'manifest.json'
+if (-not (Test-Path $manifestPath -PathType Leaf)) {
+    throw "Package manifest is missing."
+}
+$manifest = Get-Content $manifestPath -Raw | ConvertFrom-Json
+
+if ($manifest.architecture -ne 'arm64' -or $manifest.machine -ne '0xAA64') {
+    throw "Manifest architecture is not ARM64."
+}
+
+$replaceEntries = @($manifest.baselineDisposition | Where-Object disposition -eq 'replace')
+$removeEntries = @($manifest.baselineDisposition | Where-Object disposition -eq 'remove')
+if ($replaceEntries.Count -ne 10 -or $removeEntries.Count -ne 1) {
+    throw "Expected 10 replacement paths and one removal path."
+}
+if ($removeEntries[0].path -ne 'usr/lib/ssh/ssh-keysign.exe') {
+    throw "The only removal path must be usr/lib/ssh/ssh-keysign.exe."
+}
+
+foreach ($path in $expectedClientPaths) {
+    $nativePath = $path.Replace('/', [System.IO.Path]::DirectorySeparatorChar)
+    $fullPath = Join-Path $PackageDirectory $nativePath
+    if (-not (Test-Path $fullPath -PathType Leaf)) {
+        throw "Expected client file '$path' is missing."
+    }
+}
+
+$peFiles = @(Get-ChildItem -Path $PackageDirectory -Recurse -File |
+    Where-Object Extension -in @('.exe', '.dll'))
+if ($peFiles.Count -ne 14) {
+    throw "Expected 14 ARM64 PE files (10 baseline replacements, two colocated helpers, and two libcrypto copies), found $($peFiles.Count)."
+}
+foreach ($file in $peFiles) {
+    $machine = Get-PEMachine -Path $file.FullName
+    if ($machine -ne 0xAA64) {
+        throw "'$($file.FullName)' has machine 0x$($machine.ToString('X4')); expected 0xAA64."
+    }
+}
+
+$unexpectedServerFiles = Get-ChildItem -Path $PackageDirectory -Recurse -File |
+    Where-Object { $serverOnlyNames -contains $_.Name }
+if ($unexpectedServerFiles) {
+    throw "Server-only files were included: $($unexpectedServerFiles.Name -join ', ')."
+}
+
+foreach ($fileEntry in $manifest.files) {
+    $nativePath = $fileEntry.path.Replace('/', [System.IO.Path]::DirectorySeparatorChar)
+    $fullPath = Join-Path $PackageDirectory $nativePath
+    $actualHash = (Get-FileHash -Path $fullPath -Algorithm SHA256).Hash.ToLowerInvariant()
+    if ($actualHash -ne $fileEntry.sha256) {
+        throw "SHA-256 mismatch for '$($fileEntry.path)'."
+    }
+}
+
+Write-Host "Validated ARM64 client package: 10 baseline replacements, one removal, 14 ARM64 PE files, no server payload."


### PR DESCRIPTION
## Summary

- add a native `windows-11-arm` workflow that rebuilds `PowerShell/openssh-portable@b8c08ef9da9450a94a9c5ef717d96a7bd83f3332` (`v10.0.0.0`)
- repair the tag's unreproducible vcpkg lock by advancing only the registry baseline to `16fa044f80dd984c24deff5b7d0457e64c85a1e0`, the commit that introduced the requested `libcbor 0.13.0`
- run all eight upstream Win32 unit-test executables plus native client integration coverage for keys, config discovery, known_hosts, ProxyCommand, ssh-agent/add, scp, sftp, forced Windows PTY, and Git-over-SSH clone/fetch
- publish a Git for Windows layout with per-file SHA-256 and PE-machine provenance; all 14 packaged PEs must be ARM64 (`0xAA64`)
- exclude sshd, auth/session daemons, shell host, service scripts, server config, events, and moduli from the client artifact

## Downstream contract

The artifact replaces ten of the eleven current Git for Windows OpenSSH paths. `usr/lib/ssh/ssh-keysign.exe` is intentionally removed because Win32 OpenSSH does not build it and Windows host-based authentication is unsupported. PKCS#11 and security-key helpers are also colocated beside `ssh.exe`, as required by the Windows client's runtime helper discovery.

## Validation

Successful native run: https://github.com/crutkas/Win32-OpenSSH/actions/runs/31747249140

- exact source and dependency checkout/build passed with ARM64 Spectre libraries
- all 8 upstream unit tests passed
- native end-to-end client smoke passed
- artifact verification passed: 10 replacements, 1 removal, 14 ARM64 PEs, no server payload
- artifact `OpenSSH-ARM64-Client-v10.0.0.0`: `sha256:03c9f7da38d51cdb284b64a82ddbb0068e227325b21c5dfa0aef08e136966177`